### PR TITLE
Allow for --config-only backups and disabled services

### DIFF
--- a/lib/chef_backup/config.rb
+++ b/lib/chef_backup/config.rb
@@ -9,6 +9,7 @@ module ChefBackup
 
     DEFAULT_CONFIG = {
       'backup' => {
+        'config_only' => false,
         'always_dump_db' => true,
         'strategy' => 'none',
         'export_dir' => '/var/opt/chef-backup'

--- a/lib/chef_backup/version.rb
+++ b/lib/chef_backup/version.rb
@@ -1,4 +1,4 @@
 # ChefBackup module
 module ChefBackup
-  VERSION = '0.0.1.dev.4'
+  VERSION = '0.0.1.dev.4'.freeze
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,11 +17,6 @@ def private_chef!(args = {})
   ChefBackup::Config.config = args
 end
 
-# Merge attributes into existing cli_args
-def cli_args(*args)
-  Chef::Mixin::DeepMerge.deep_merge!(*args, ChefBackup::Config.config)
-end
-
 # Overwrite config with given CLI args
 def cli_args!(args)
   ChefBackup::Config.config = args

--- a/spec/unit/strategy/backup/tar_spec.rb
+++ b/spec/unit/strategy/backup/tar_spec.rb
@@ -26,13 +26,13 @@ describe ChefBackup::Strategy::TarBackup do
       allow(subject).to receive(:dump_db).and_return(true)
     end
 
-    context "when config_only is true" do
+    context 'when config_only is true' do
       before do
-        private_chef('backup' => { 'config_only' => true})
+        private_chef('backup' => { 'config_only' => true })
       end
 
-      it_behaves_like "a tar based backup"
-      it_behaves_like "a tar based frontend"
+      it_behaves_like 'a tar based backup'
+      it_behaves_like 'a tar based frontend'
     end
 
     context 'on a frontend' do
@@ -190,7 +190,8 @@ describe ChefBackup::Strategy::TarBackup do
 
   describe '.write_manifest' do
     let(:manifest) do
-      { 'some' => {
+      { 'some' =>
+        {
           'nested' => {
             'hash' => true
           },
@@ -278,10 +279,10 @@ describe ChefBackup::Strategy::TarBackup do
       end
     end
 
-    context "when config_only is true" do
+    context 'when config_only is true' do
       before do
-        private_chef('role' => 'standalone', 'backup' => { 'config_only' => true})
-        data_mock = double("DataMap")
+        private_chef('role' => 'standalone', 'backup' => { 'config_only' => true })
+        data_mock = double('DataMap')
         allow(subject).to receive(:data_map).and_return(data_mock)
       end
 

--- a/spec/unit/strategy/restore/tar_spec.rb
+++ b/spec/unit/strategy/restore/tar_spec.rb
@@ -125,7 +125,7 @@ describe ChefBackup::Strategy::TarRestore do
   end
 
   describe '.manifest' do
-    let(:json) { "{\"some\":\"json\"}" }
+    let(:json) { '{"some":"json"}' }
     let(:manifest_json) { File.join(restore_dir, 'manifest.json') }
 
     it 'parses the manifest from the restore dir' do


### PR DESCRIPTION
It is not unusual to run a standalone configuration with services
disabled (because they are run externally).  Further, in some
topologies, you may _only_ need to backup secrets and config on the
frontend as everything else is handled by Chef Backend.
