### PR TITLE
Parameterize paths to support Chef Backend

### DIFF
--- a/chef_backup.gemspec
+++ b/chef_backup.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'guard-rspec'
   spec.add_development_dependency 'pry-rescue'
-  spec.add_development_dependency 'rubocop', '>= 0.32.1'
+  spec.add_development_dependency 'rubocop', '~> 0.36.0'
   spec.add_development_dependency 'simplecov'
 end

--- a/lib/chef_backup/config.rb
+++ b/lib/chef_backup/config.rb
@@ -7,12 +7,14 @@ module ChefBackup
   class Config
     extend Forwardable
 
+    DEFAULT_BASE = 'private_chef'.freeze
     DEFAULT_CONFIG = {
       'backup' => {
-        'config_only' => false,
         'always_dump_db' => true,
         'strategy' => 'none',
-        'export_dir' => '/var/opt/chef-backup'
+        'export_dir' => '/var/opt/chef-backup',
+        'project_name' => 'opscode',
+        'ctl-command' => 'chef-server-ctl'
       }
     }.freeze
 
@@ -46,11 +48,16 @@ module ChefBackup
     # @param config [Hash] a Hash of the private-chef-running.json
     #
     def initialize(config = {})
-      config['private_chef'] ||= {}
-      config['private_chef']['backup'] ||= {}
-      config['private_chef']['backup'] =
-        DEFAULT_CONFIG['backup'].merge(config['private_chef']['backup'])
+      config['config_base'] ||= DEFAULT_BASE
+      base = config['config_base']
+      config[base] ||= {}
+      config[base]['backup'] ||= {}
+      config[base]['backup'] = DEFAULT_CONFIG['backup'].merge(config[base]['backup'])
       @config = config
+    end
+
+    def to_hash
+      @config
     end
 
     def_delegators :@config, :[], :[]=

--- a/lib/chef_backup/runner.rb
+++ b/lib/chef_backup/runner.rb
@@ -17,7 +17,7 @@ module ChefBackup
     #
     def initialize(running_config)
       ChefBackup::Config.config = running_config
-      ChefBackup::Logger.logger(private_chef['backup']['logfile'] || nil)
+      ChefBackup::Logger.logger(service_config['backup']['logfile'] || nil)
     end
 
     #
@@ -26,6 +26,13 @@ module ChefBackup
     def backup
       @backup ||= ChefBackup::Strategy.backup(backup_strategy)
       @backup.backup
+    end
+
+    #
+    # @return [ChefBackup::Config]
+    #
+    def config
+      ChefBackup::Config.config
     end
 
     #
@@ -40,7 +47,7 @@ module ChefBackup
     # @return [String] String name of the configured backup strategy
     #
     def backup_strategy
-      config['private_chef']['backup']['strategy']
+      service_config['backup']['strategy']
     end
 
     #


### PR DESCRIPTION
This commit allows the user to configure the config_base (what hash key
is used for service config), project_name, and the ctl-command.
