### PR TITLE
Add an attr_writer for manifest in TarRestore

### DIFF
--- a/lib/chef_backup/strategy/restore/tar.rb
+++ b/lib/chef_backup/strategy/restore/tar.rb
@@ -43,6 +43,7 @@ class TarRestore
     log 'Restoration Completed!'
   end
 
+  attr_writer :manifest
   def manifest
     @manifest ||= begin
       manifest = File.expand_path(File.join(ChefBackup::Config['restore_dir'],


### PR DESCRIPTION
Chef Backend is currently being a bit gross and using this class
directly. Having access to the manifest directly allows us to modify it
before restoring.
