### PR TITLE
Don't require chef by vendoring deep_merge

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -18,4 +18,8 @@ Metrics/AbcSize:
   Max: 40
 AllCops:
   Exclude:
+    - 'lib/chef_backup/deep_merge.rb'
+    - 'lib/chef_backup/mash.rb'
+    - 'spec/unit/mash_spec.rb'
+    - 'spec/unit/deep_merge_spec.rb'
     - 'Guardfile'

--- a/chef_backup.gemspec
+++ b/chef_backup.gemspec
@@ -18,10 +18,8 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(/^(test|spec|features)/)
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'di-ruby-lvm'
   spec.add_dependency 'mixlib-shellout'
   spec.add_dependency 'highline'
-  spec.add_dependency 'chef'
 
   spec.add_development_dependency 'bundler', '~> 1.6'
   spec.add_development_dependency 'rake'

--- a/lib/chef_backup/deep_merge.rb
+++ b/lib/chef_backup/deep_merge.rb
@@ -1,0 +1,145 @@
+#
+# Author:: Adam Jacob (<adam@chef.io>)
+# Author:: Steve Midgley (http://www.misuse.org/science)
+# Copyright:: Copyright 2009-2016, Chef Software Inc.
+# Copyright:: Copyright 2008-2016, Steve Midgley
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+require 'chef_backup/mash'
+
+#
+# DANGER! THIS FILE WAS VENDORDED FROM CHEF. IF YOU ARE
+# MAKING A CHANGE HERE, CONSIDER WHETHER IT IS REQUIRED IN CHEF ALSO?
+#
+module ChefBackup
+  module Mixin
+    # == Chef::Mixin::DeepMerge
+    # Implements a deep merging algorithm for nested data structures.
+    # ==== Notice:
+    #   This code was originally imported from deep_merge by Steve Midgley.
+    #   deep_merge is available under the MIT license from
+    #   http://trac.misuse.org/science/wiki/DeepMerge
+    module DeepMerge
+
+      extend self
+
+      def merge(first, second)
+        first  = Mash.new(first)  unless first.kind_of?(Mash)
+        second = Mash.new(second) unless second.kind_of?(Mash)
+
+        DeepMerge.deep_merge(second, first)
+      end
+
+      class InvalidParameter < StandardError; end
+
+      # Deep Merge core documentation.
+      # deep_merge! method permits merging of arbitrary child elements. The two top level
+      # elements must be hashes. These hashes can contain unlimited (to stack limit) levels
+      # of child elements. These child elements to not have to be of the same types.
+      # Where child elements are of the same type, deep_merge will attempt to merge them together.
+      # Where child elements are not of the same type, deep_merge will skip or optionally overwrite
+      # the destination element with the contents of the source element at that level.
+      # So if you have two hashes like this:
+      #   source = {:x => [1,2,3], :y => 2}
+      #   dest =   {:x => [4,5,'6'], :y => [7,8,9]}
+      #   dest.deep_merge!(source)
+      #   Results: {:x => [1,2,3,4,5,'6'], :y => 2}
+      # By default, "deep_merge!" will overwrite any unmergeables and merge everything else.
+      # To avoid this, use "deep_merge" (no bang/exclamation mark)
+      def deep_merge!(source, dest)
+        # if dest doesn't exist, then simply copy source to it
+        if dest.nil?
+          dest = source; return dest
+        end
+
+        case source
+        when nil
+          dest
+        when Hash
+          if dest.kind_of?(Hash)
+            source.each do |src_key, src_value|
+              if dest[src_key]
+                dest[src_key] = deep_merge!(src_value, dest[src_key])
+              else # dest[src_key] doesn't exist so we take whatever source has
+                dest[src_key] = src_value
+              end
+            end
+          else # dest isn't a hash, so we overwrite it completely
+            dest = source
+          end
+        when Array
+          if dest.kind_of?(Array)
+            dest = dest | source
+          else
+            dest = source
+          end
+        when String
+          dest = source
+        else # src_hash is not an array or hash, so we'll have to overwrite dest
+          dest = source
+        end
+        dest
+      end # deep_merge!
+
+      def hash_only_merge(merge_onto, merge_with)
+        hash_only_merge!(safe_dup(merge_onto), safe_dup(merge_with))
+      end
+
+      def safe_dup(thing)
+        thing.dup
+      rescue TypeError
+        thing
+      end
+
+      # Deep merge without Array merge.
+      # `merge_onto` is the object that will "lose" in case of conflict.
+      # `merge_with` is the object whose values will replace `merge_onto`s
+      # values when there is a conflict.
+      def hash_only_merge!(merge_onto, merge_with)
+        # If there are two Hashes, recursively merge.
+        if merge_onto.kind_of?(Hash) && merge_with.kind_of?(Hash)
+          merge_with.each do |key, merge_with_value|
+            value =
+              if merge_onto.has_key?(key)
+                hash_only_merge(merge_onto[key], merge_with_value)
+              else
+                merge_with_value
+              end
+
+            if merge_onto.respond_to?(:public_method_that_only_deep_merge_should_use)
+              # we can't call ImmutableMash#[]= because its immutable, but we need to mutate it to build it in-place
+              merge_onto.public_method_that_only_deep_merge_should_use(key, value)
+            else
+              merge_onto[key] = value
+            end
+          end
+          merge_onto
+
+        # If merge_with is nil, don't replace merge_onto
+        elsif merge_with.nil?
+          merge_onto
+
+        # In all other cases, replace merge_onto with merge_with
+        else
+          merge_with
+        end
+      end
+
+      def deep_merge(source, dest)
+        deep_merge!(safe_dup(source), safe_dup(dest))
+      end
+
+    end
+  end
+end

--- a/lib/chef_backup/mash.rb
+++ b/lib/chef_backup/mash.rb
@@ -1,0 +1,226 @@
+# Copyright 2009-2016, Dan Kubb
+
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+# ---
+# ---
+
+# Some portions of blank.rb and mash.rb are verbatim copies of software
+# licensed under the MIT license. That license is included below:
+
+# Copyright 2005-2016, David Heinemeier Hansson
+
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+# This class has dubious semantics and we only have it so that people can write
+# params[:key] instead of params['key'].
+class Mash < Hash
+
+  # @param constructor<Object>
+  #   The default value for the mash. Defaults to an empty hash.
+  #
+  # @details [Alternatives]
+  #   If constructor is a Hash, a new mash will be created based on the keys of
+  #   the hash and no default value will be set.
+  def initialize(constructor = {})
+    if constructor.is_a?(Hash)
+      super()
+      update(constructor)
+    else
+      super(constructor)
+    end
+  end
+
+  # @param orig<Object> Mash being copied
+  #
+  # @return [Object] A new copied Mash
+  def initialize_copy(orig)
+    super
+    # Handle nested values
+    each do |k, v|
+      if v.kind_of?(Mash) || v.is_a?(Array)
+        self[k] = v.dup
+      end
+    end
+    self
+  end
+
+  # @param key<Object> The default value for the mash. Defaults to nil.
+  #
+  # @details [Alternatives]
+  #   If key is a Symbol and it is a key in the mash, then the default value will
+  #   be set to the value matching the key.
+  def default(key = nil)
+    if key.is_a?(Symbol) && include?(key = key.to_s)
+      self[key]
+    else
+      super
+    end
+  end
+
+  alias_method :regular_writer, :[]= unless method_defined?(:regular_writer)
+  alias_method :regular_update, :update unless method_defined?(:regular_update)
+
+  # @param key<Object> The key to set.
+  # @param value<Object>
+  #   The value to set the key to.
+  #
+  # @see Mash#convert_key
+  # @see Mash#convert_value
+  def []=(key, value)
+    regular_writer(convert_key(key), convert_value(value))
+  end
+
+  # @param other_hash<Hash>
+  #   A hash to update values in the mash with. The keys and the values will be
+  #   converted to Mash format.
+  #
+  # @return [Mash] The updated mash.
+  def update(other_hash)
+    other_hash.each_pair { |key, value| regular_writer(convert_key(key), convert_value(value)) }
+    self
+  end
+
+  alias_method :merge!, :update
+
+  # @param key<Object> The key to check for. This will be run through convert_key.
+  #
+  # @return [Boolean] True if the key exists in the mash.
+  def key?(key)
+    super(convert_key(key))
+  end
+
+  # def include? def has_key? def member?
+  alias_method :include?, :key?
+  alias_method :has_key?, :key?
+  alias_method :member?, :key?
+
+  # @param key<Object> The key to fetch. This will be run through convert_key.
+  # @param *extras<Array> Default value.
+  #
+  # @return [Object] The value at key or the default value.
+  def fetch(key, *extras)
+    super(convert_key(key), *extras)
+  end
+
+  # @param *indices<Array>
+  #   The keys to retrieve values for. These will be run through +convert_key+.
+  #
+  # @return [Array] The values at each of the provided keys
+  def values_at(*indices)
+    indices.collect { |key| self[convert_key(key)] }
+  end
+
+  # @param hash<Hash> The hash to merge with the mash.
+  #
+  # @return [Mash] A new mash with the hash values merged in.
+  def merge(hash)
+    self.dup.update(hash)
+  end
+
+  # @param key<Object>
+  #   The key to delete from the mash.\
+  def delete(key)
+    super(convert_key(key))
+  end
+
+  # @param *rejected<Array[(String, Symbol)] The mash keys to exclude.
+  #
+  # @return [Mash] A new mash without the selected keys.
+  #
+  # @example
+  #   { :one => 1, :two => 2, :three => 3 }.except(:one)
+  #     #=> { "two" => 2, "three" => 3 }
+  def except(*keys)
+    super(*keys.map { |k| convert_key(k) })
+  end
+
+  # Used to provide the same interface as Hash.
+  #
+  # @return [Mash] This mash unchanged.
+  def stringify_keys!; self end
+
+  # @return [Hash] The mash as a Hash with symbolized keys.
+  def symbolize_keys
+    h = Hash.new(default)
+    each { |key, val| h[key.to_sym] = val }
+    h
+  end
+
+  # @return [Hash] The mash as a Hash with string keys.
+  def to_hash
+    Hash.new(default).merge(self)
+  end
+
+  # @return [Mash] Convert a Hash into a Mash
+  # The input Hash's default value is maintained
+  def self.from_hash(hash)
+    mash = Mash.new(hash)
+    mash.default = hash.default
+    mash
+  end
+
+  protected
+
+  # @param key<Object> The key to convert.
+  #
+  # @param [Object]
+  #   The converted key. If the key was a symbol, it will be converted to a
+  #   string.
+  #
+  # @api private
+  def convert_key(key)
+    key.kind_of?(Symbol) ? key.to_s : key
+  end
+
+  # @param value<Object> The value to convert.
+  #
+  # @return [Object]
+  #   The converted value. A Hash or an Array of hashes, will be converted to
+  #   their Mash equivalents.
+  #
+  # @api private
+  def convert_value(value)
+    if value.class == Hash
+      Mash.from_hash(value)
+    elsif value.is_a?(Array)
+      value.collect { |e| convert_value(e) }
+    else
+      value
+    end
+  end
+end

--- a/lib/chef_backup/strategy/restore/tar.rb
+++ b/lib/chef_backup/strategy/restore/tar.rb
@@ -1,7 +1,7 @@
 require 'fileutils'
 require 'pathname'
 require 'forwardable'
-require 'chef/mixin/deep_merge'
+require 'chef_backup/deep_merge'
 
 # rubocop:disable IndentationWidth
 module ChefBackup
@@ -11,7 +11,7 @@ class TarRestore
   # rubocop:enable IndentationWidth
   include ChefBackup::Helpers
   include ChefBackup::Exceptions
-  include Chef::Mixin::DeepMerge
+  include ChefBackup::Mixin::DeepMerge
   extend Forwardable
 
   attr_accessor :tarball_path

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,11 +5,11 @@ require 'chef_backup'
 require 'bundler/setup'
 require 'json'
 require 'tempfile'
-require 'chef/mixin/deep_merge'
+require 'chef_backup/deep_merge'
 
 # Merge attributes into existing running_config
 def private_chef(*args)
-  Chef::Mixin::DeepMerge.deep_merge!(*args, ChefBackup::Config['private_chef'])
+  ChefBackup::Mixin::DeepMerge.deep_merge!(*args, ChefBackup::Config['private_chef'])
 end
 
 # Overwrite config with given attributes

--- a/spec/unit/deep_merge_spec.rb
+++ b/spec/unit/deep_merge_spec.rb
@@ -1,0 +1,342 @@
+#
+# Author:: Matthew Kent (<mkent@magoazul.com>)
+# Author:: Steve Midgley (http://www.misuse.org/science)
+# Copyright:: Copyright 2010-2016, Matthew Kent
+# Copyright:: Copyright 2008-2016, Steve Midgley
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Notice:
+# This code is imported from deep_merge by Steve Midgley. deep_merge is
+# available under the MIT license from
+# http://trac.misuse.org/science/wiki/DeepMerge
+
+require "spec_helper"
+
+# Test coverage from the original author converted to rspec
+describe ChefBackup::Mixin::DeepMerge, "deep_merge!" do
+  before do
+    @dm = ChefBackup::Mixin::DeepMerge
+    @field_ko_prefix = "!merge"
+  end
+
+  # deep_merge core tests - moving from basic to more complex
+
+  it "tests merging an hash w/array into blank hash" do
+    hash_src = { "id" => "2" }
+    hash_dst = {}
+    @dm.deep_merge!(hash_src.dup, hash_dst)
+    expect(hash_dst).to eq(hash_src)
+  end
+
+  it "tests merging an hash w/array into blank hash" do
+    hash_src = { "region" => { "id" => %w{227 2} } }
+    hash_dst = {}
+    @dm.deep_merge!(hash_src, hash_dst)
+    expect(hash_dst).to eq(hash_src)
+  end
+
+  it "tests merge from empty hash" do
+    hash_src = {}
+    hash_dst = { "property" => %w{2 4} }
+    @dm.deep_merge!(hash_src, hash_dst)
+    expect(hash_dst).to eq({ "property" => %w{2 4} })
+  end
+
+  it "tests merge to empty hash" do
+    hash_src = { "property" => %w{2 4} }
+    hash_dst = {}
+    @dm.deep_merge!(hash_src, hash_dst)
+    expect(hash_dst).to eq({ "property" => %w{2 4} })
+  end
+
+  it "tests simple string overwrite" do
+    hash_src = { "name" => "value" }
+    hash_dst = { "name" => "value1" }
+    @dm.deep_merge!(hash_src, hash_dst)
+    expect(hash_dst).to eq({ "name" => "value" })
+  end
+
+  it "tests simple string overwrite of empty hash" do
+    hash_src = { "name" => "value" }
+    hash_dst = {}
+    @dm.deep_merge!(hash_src, hash_dst)
+    expect(hash_dst).to eq(hash_src)
+  end
+
+  it "tests hashes holding array" do
+    hash_src = { "property" => %w{1 3} }
+    hash_dst = { "property" => %w{2 4} }
+    @dm.deep_merge!(hash_src, hash_dst)
+    expect(hash_dst).to eq({ "property" => %w{2 4 1 3} })
+  end
+
+  it "tests hashes holding hashes holding arrays (array with duplicate elements is merged with dest then src" do
+    hash_src = { "property" => { "bedroom_count" => %w{1 2}, "bathroom_count" => ["1", "4+"] } }
+    hash_dst = { "property" => { "bedroom_count" => %w{3 2}, "bathroom_count" => ["2"] } }
+    @dm.deep_merge!(hash_src, hash_dst)
+    expect(hash_dst).to eq({ "property" => { "bedroom_count" => %w{3 2 1}, "bathroom_count" => ["2", "1", "4+"] } })
+  end
+
+  it "tests hash holding hash holding array v string (string is overwritten by array)" do
+    hash_src = { "property" => { "bedroom_count" => %w{1 2}, "bathroom_count" => ["1", "4+"] } }
+    hash_dst = { "property" => { "bedroom_count" => "3", "bathroom_count" => ["2"] } }
+    @dm.deep_merge!(hash_src, hash_dst)
+    expect(hash_dst).to eq({ "property" => { "bedroom_count" => %w{1 2}, "bathroom_count" => ["2", "1", "4+"] } })
+  end
+
+  it "tests hash holding hash holding string v array (array is overwritten by string)" do
+    hash_src = { "property" => { "bedroom_count" => "3", "bathroom_count" => ["1", "4+"] } }
+    hash_dst = { "property" => { "bedroom_count" => %w{1 2}, "bathroom_count" => ["2"] } }
+    @dm.deep_merge!(hash_src, hash_dst)
+    expect(hash_dst).to eq({ "property" => { "bedroom_count" => "3", "bathroom_count" => ["2", "1", "4+"] } })
+  end
+
+  it "tests hash holding hash holding hash v array (array is overwritten by hash)" do
+    hash_src = { "property" => { "bedroom_count" => { "king_bed" => 3, "queen_bed" => 1 }, "bathroom_count" => ["1", "4+"] } }
+    hash_dst = { "property" => { "bedroom_count" => %w{1 2}, "bathroom_count" => ["2"] } }
+    @dm.deep_merge!(hash_src, hash_dst)
+    expect(hash_dst).to eq({ "property" => { "bedroom_count" => { "king_bed" => 3, "queen_bed" => 1 }, "bathroom_count" => ["2", "1", "4+"] } })
+  end
+
+  it "tests 3 hash layers holding integers (integers are overwritten by source)" do
+    hash_src = { "property" => { "bedroom_count" => { "king_bed" => 3, "queen_bed" => 1 }, "bathroom_count" => ["1", "4+"] } }
+    hash_dst = { "property" => { "bedroom_count" => { "king_bed" => 2, "queen_bed" => 4 }, "bathroom_count" => ["2"] } }
+    @dm.deep_merge!(hash_src, hash_dst)
+    expect(hash_dst).to eq({ "property" => { "bedroom_count" => { "king_bed" => 3, "queen_bed" => 1 }, "bathroom_count" => ["2", "1", "4+"] } })
+  end
+
+  it "tests 3 hash layers holding arrays of int (arrays are merged)" do
+    hash_src = { "property" => { "bedroom_count" => { "king_bed" => [3], "queen_bed" => [1] }, "bathroom_count" => ["1", "4+"] } }
+    hash_dst = { "property" => { "bedroom_count" => { "king_bed" => [2], "queen_bed" => [4] }, "bathroom_count" => ["2"] } }
+    @dm.deep_merge!(hash_src, hash_dst)
+    expect(hash_dst).to eq({ "property" => { "bedroom_count" => { "king_bed" => [2, 3], "queen_bed" => [4, 1] }, "bathroom_count" => ["2", "1", "4+"] } })
+  end
+
+  it "tests 1 hash overwriting 3 hash layers holding arrays of int" do
+    hash_src = { "property" => "1" }
+    hash_dst = { "property" => { "bedroom_count" => { "king_bed" => [2], "queen_bed" => [4] }, "bathroom_count" => ["2"] } }
+    @dm.deep_merge!(hash_src, hash_dst)
+    expect(hash_dst).to eq({ "property" => "1" })
+  end
+
+  it "tests 3 hash layers holding arrays of int (arrays are merged) but second hash's array is overwritten" do
+    hash_src = { "property" => { "bedroom_count" => { "king_bed" => [3], "queen_bed" => [1] }, "bathroom_count" => "1" } }
+    hash_dst = { "property" => { "bedroom_count" => { "king_bed" => [2], "queen_bed" => [4] }, "bathroom_count" => ["2"] } }
+    @dm.deep_merge!(hash_src, hash_dst)
+    expect(hash_dst).to eq({ "property" => { "bedroom_count" => { "king_bed" => [2, 3], "queen_bed" => [4, 1] }, "bathroom_count" => "1" } })
+  end
+
+  it "tests 3 hash layers holding arrays of int, but one holds int. This one overwrites, but the rest merge" do
+    hash_src = { "property" => { "bedroom_count" => { "king_bed" => 3, "queen_bed" => [1] }, "bathroom_count" => ["1"] } }
+    hash_dst = { "property" => { "bedroom_count" => { "king_bed" => [2], "queen_bed" => [4] }, "bathroom_count" => ["2"] } }
+    @dm.deep_merge!(hash_src, hash_dst)
+    expect(hash_dst).to eq({ "property" => { "bedroom_count" => { "king_bed" => 3, "queen_bed" => [4, 1] }, "bathroom_count" => %w{2 1} } })
+  end
+
+  it "tests 3 hash layers holding arrays of int, but source is incomplete." do
+    hash_src = { "property" => { "bedroom_count" => { "king_bed" => [3] }, "bathroom_count" => ["1"] } }
+    hash_dst = { "property" => { "bedroom_count" => { "king_bed" => [2], "queen_bed" => [4] }, "bathroom_count" => ["2"] } }
+    @dm.deep_merge!(hash_src, hash_dst)
+    expect(hash_dst).to eq({ "property" => { "bedroom_count" => { "king_bed" => [2, 3], "queen_bed" => [4] }, "bathroom_count" => %w{2 1} } })
+  end
+
+  it "tests 3 hash layers holding arrays of int, but source is shorter and has new 2nd level ints." do
+    hash_src = { "property" => { "bedroom_count" => { 2 => 3, "king_bed" => [3] }, "bathroom_count" => ["1"] } }
+    hash_dst = { "property" => { "bedroom_count" => { "king_bed" => [2], "queen_bed" => [4] }, "bathroom_count" => ["2"] } }
+    @dm.deep_merge!(hash_src, hash_dst)
+    expect(hash_dst).to eq({ "property" => { "bedroom_count" => { 2 => 3, "king_bed" => [2, 3], "queen_bed" => [4] }, "bathroom_count" => %w{2 1} } })
+  end
+
+  it "tests 3 hash layers holding arrays of int, but source is empty" do
+    hash_src = {}
+    hash_dst = { "property" => { "bedroom_count" => { "king_bed" => [2], "queen_bed" => [4] }, "bathroom_count" => ["2"] } }
+    @dm.deep_merge!(hash_src, hash_dst)
+    expect(hash_dst).to eq({ "property" => { "bedroom_count" => { "king_bed" => [2], "queen_bed" => [4] }, "bathroom_count" => ["2"] } })
+  end
+
+  it "tests 3 hash layers holding arrays of int, but dest is empty" do
+    hash_src = { "property" => { "bedroom_count" => { 2 => 3, "king_bed" => [3] }, "bathroom_count" => ["1"] } }
+    hash_dst = {}
+    @dm.deep_merge!(hash_src, hash_dst)
+    expect(hash_dst).to eq({ "property" => { "bedroom_count" => { 2 => 3, "king_bed" => [3] }, "bathroom_count" => ["1"] } })
+  end
+
+  it "tests hash holding arrays of arrays" do
+    hash_src = { %w{1 2 3} => %w{1 2} }
+    hash_dst = { %w{4 5} => ["3"] }
+    @dm.deep_merge!(hash_src, hash_dst)
+    expect(hash_dst).to eq({ %w{1 2 3} => %w{1 2}, %w{4 5} => ["3"] })
+  end
+
+  it "tests merging of hash with blank hash, and make sure that source array split does not function when turned off" do
+    hash_src = { "property" => { "bedroom_count" => ["1", "2,3"] } }
+    hash_dst = {}
+    @dm.deep_merge!(hash_src, hash_dst)
+    expect(hash_dst).to eq({ "property" => { "bedroom_count" => ["1", "2,3"] } })
+  end
+
+  it "tests merging into a blank hash" do
+    hash_src = { "action" => "browse", "controller" => "results" }
+    hash_dst = {}
+    @dm.deep_merge!(hash_src, hash_dst)
+    expect(hash_dst).to eq(hash_src)
+  end
+
+  it "tests are unmerged hashes passed unmodified w/out :unpack_arrays?" do
+    hash_src = { "amenity" => { "id" => ["26,27"] } }
+    hash_dst = {}
+    @dm.deep_merge!(hash_src, hash_dst)
+    expect(hash_dst).to eq({ "amenity" => { "id" => ["26,27"] } })
+  end
+
+  it "tests hash of array of hashes" do
+    hash_src = { "item" => [{ "1" => "3" }, { "2" => "4" }] }
+    hash_dst = { "item" => [{ "3" => "5" }] }
+    @dm.deep_merge!(hash_src, hash_dst)
+    expect(hash_dst).to eq({ "item" => [{ "3" => "5" }, { "1" => "3" }, { "2" => "4" }] })
+  end
+
+  # Additions since import
+  it "should overwrite true with false when merging boolean values" do
+    hash_src = { "valid" => false }
+    hash_dst = { "valid" => true }
+    @dm.deep_merge!(hash_src, hash_dst)
+    expect(hash_dst).to eq({ "valid" => false })
+  end
+
+  it "should overwrite false with true when merging boolean values" do
+    hash_src = { "valid" => true }
+    hash_dst = { "valid" => false }
+    @dm.deep_merge!(hash_src, hash_dst)
+    expect(hash_dst).to eq({ "valid" => true })
+  end
+
+  it "should overwrite a string with an empty string when merging string values" do
+    hash_src = { "item" => " " }
+    hash_dst = { "item" => "orange" }
+    @dm.deep_merge!(hash_src, hash_dst)
+    expect(hash_dst).to eq({ "item" => " " })
+  end
+
+  it "should overwrite an empty string with a string when merging string values" do
+    hash_src = { "item" => "orange" }
+    hash_dst = { "item" => " " }
+    @dm.deep_merge!(hash_src, hash_dst)
+    expect(hash_dst).to eq({ "item" => "orange" })
+  end
+end # deep_merge!
+
+# Chef specific
+describe ChefBackup::Mixin::DeepMerge do
+  before do
+    @dm = ChefBackup::Mixin::DeepMerge
+  end
+
+  describe "merge" do
+    it "should merge a hash into an empty hash" do
+      hash_dst = {}
+      hash_src = { "id" => "2" }
+      expect(@dm.merge(hash_dst, hash_src)).to eq(hash_src)
+    end
+
+    it "should merge a nested hash into an empty hash" do
+      hash_dst = {}
+      hash_src = { "region" => { "id" => %w{227 2} } }
+      expect(@dm.merge(hash_dst, hash_src)).to eq(hash_src)
+    end
+
+    it "should overwrite as string value when merging hashes" do
+      hash_dst = { "name" => "value1" }
+      hash_src = { "name" => "value" }
+      expect(@dm.merge(hash_dst, hash_src)).to eq({ "name" => "value" })
+    end
+
+    it "should merge arrays within hashes" do
+      hash_dst = { "property" => %w{2 4} }
+      hash_src = { "property" => %w{1 3} }
+      expect(@dm.merge(hash_dst, hash_src)).to eq({ "property" => %w{2 4 1 3} })
+    end
+
+    it "should merge deeply nested hashes" do
+      hash_dst = { "property" => { "values" => { "are" => "falling", "can" => "change" } } }
+      hash_src = { "property" => { "values" => { "are" => "stable", "may" => "rise" } } }
+      expect(@dm.merge(hash_dst, hash_src)).to eq({ "property" => { "values" => { "are" => "stable", "can" => "change", "may" => "rise" } } })
+    end
+
+    it "should not modify the source or destination during the merge" do
+      hash_dst = { "property" => %w{1 2 3} }
+      hash_src = { "property" => %w{4 5 6} }
+      ret = @dm.merge(hash_dst, hash_src)
+      expect(hash_dst).to eq({ "property" => %w{1 2 3} })
+      expect(hash_src).to eq({ "property" => %w{4 5 6} })
+      expect(ret).to eq({ "property" => %w{1 2 3 4 5 6} })
+    end
+
+    it "should not error merging un-dupable objects" do
+      @dm.deep_merge(nil, 4)
+    end
+
+  end
+
+  describe "hash-only merging" do
+    it "merges Hashes like normal deep merge" do
+      merge_ee_hash = { "top_level_a" => { "1_deep_a" => "1-a-merge-ee", "1_deep_b" => "1-deep-b-merge-ee" }, "top_level_b" => "top-level-b-merge-ee" }
+      merge_with_hash = { "top_level_a" => { "1_deep_b" => "1-deep-b-merged-onto", "1_deep_c" => "1-deep-c-merged-onto" }, "top_level_b" => "top-level-b-merged-onto" }
+
+      merged_result = @dm.hash_only_merge(merge_ee_hash, merge_with_hash)
+
+      expect(merged_result["top_level_b"]).to eq("top-level-b-merged-onto")
+      expect(merged_result["top_level_a"]["1_deep_a"]).to eq("1-a-merge-ee")
+      expect(merged_result["top_level_a"]["1_deep_b"]).to eq("1-deep-b-merged-onto")
+      expect(merged_result["top_level_a"]["1_deep_c"]).to eq("1-deep-c-merged-onto")
+    end
+
+    it "replaces arrays rather than merging them" do
+      merge_ee_hash = { "top_level_a" => { "1_deep_a" => "1-a-merge-ee", "1_deep_b" => %w{A A A} }, "top_level_b" => "top-level-b-merge-ee" }
+      merge_with_hash = { "top_level_a" => { "1_deep_b" => %w{B B B}, "1_deep_c" => "1-deep-c-merged-onto" }, "top_level_b" => "top-level-b-merged-onto" }
+
+      merged_result = @dm.hash_only_merge(merge_ee_hash, merge_with_hash)
+
+      expect(merged_result["top_level_b"]).to eq("top-level-b-merged-onto")
+      expect(merged_result["top_level_a"]["1_deep_a"]).to eq("1-a-merge-ee")
+      expect(merged_result["top_level_a"]["1_deep_b"]).to eq(%w{B B B})
+    end
+
+    it "replaces non-hash items with hashes when there's a conflict" do
+      merge_ee_hash = { "top_level_a" => "top-level-a-mergee", "top_level_b" => "top-level-b-merge-ee" }
+      merge_with_hash = { "top_level_a" => { "1_deep_b" => %w{B B B}, "1_deep_c" => "1-deep-c-merged-onto" }, "top_level_b" => "top-level-b-merged-onto" }
+
+      merged_result = @dm.hash_only_merge(merge_ee_hash, merge_with_hash)
+
+      expect(merged_result["top_level_a"]).to be_a(Hash)
+      expect(merged_result["top_level_a"]["1_deep_a"]).to be_nil
+      expect(merged_result["top_level_a"]["1_deep_b"]).to eq(%w{B B B})
+    end
+
+    it "does not mutate deeply-nested original hashes by default" do
+      merge_ee_hash =   { "top_level_a" => { "1_deep_a" => { "2_deep_a" => { "3_deep_a" => "foo" } } } }
+      merge_with_hash = { "top_level_a" => { "1_deep_a" => { "2_deep_a" => { "3_deep_b" => "bar" } } } }
+      @dm.hash_only_merge(merge_ee_hash, merge_with_hash)
+      expect(merge_ee_hash).to eq({ "top_level_a" => { "1_deep_a" => { "2_deep_a" => { "3_deep_a" => "foo" } } } })
+      expect(merge_with_hash).to eq({ "top_level_a" => { "1_deep_a" => { "2_deep_a" => { "3_deep_b" => "bar" } } } })
+    end
+
+    it "does not error merging un-dupable items" do
+      merge_ee_hash = { "top_level_a" => 1, "top_level_b" => false }
+      merge_with_hash = { "top_level_a" => 2, "top_level_b" => true }
+      @dm.hash_only_merge(merge_ee_hash, merge_with_hash)
+    end
+  end
+end

--- a/spec/unit/mash_spec.rb
+++ b/spec/unit/mash_spec.rb
@@ -1,0 +1,51 @@
+#
+# Author:: Matthew Kent (<mkent@magoazul.com>)
+# Copyright:: Copyright 2011-2016, Chef Software Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require "spec_helper"
+require "chef_backup/mash"
+
+describe Mash do
+  it "should duplicate a simple key/value mash to a new mash" do
+    data = { :x => "one", :y => "two", :z => "three" }
+    @orig = Mash.new(data)
+    @copy = @orig.dup
+    expect(@copy.to_hash).to eq(Mash.new(data).to_hash)
+    @copy[:x] = "four"
+    expect(@orig[:x]).to eq("one")
+  end
+
+  it "should duplicate a mash with an array to a new mash" do
+    data = { :x => "one", :y => "two", :z => [1, 2, 3] }
+    @orig = Mash.new(data)
+    @copy = @orig.dup
+    expect(@copy.to_hash).to eq(Mash.new(data).to_hash)
+    @copy[:z] << 4
+    expect(@orig[:z]).to eq([1, 2, 3])
+  end
+
+  it "should duplicate a nested mash to a new mash" do
+    data = { :x => "one", :y => "two", :z => Mash.new({ :a => [1, 2, 3] }) }
+    @orig = Mash.new(data)
+    @copy = @orig.dup
+    expect(@copy.to_hash).to eq(Mash.new(data).to_hash)
+    @copy[:z][:a] << 4
+    expect(@orig[:z][:a]).to eq([1, 2, 3])
+  end
+
+  # add more!
+end

--- a/spec/unit/strategy/backup/tar_spec.rb
+++ b/spec/unit/strategy/backup/tar_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
-require 'chef/mixin/deep_merge'
+require 'chef_backup/deep_merge'
 require_relative 'shared_examples/backup'
 
 describe ChefBackup::Strategy::TarBackup do


### PR DESCRIPTION
Chef is a big dependency to pull in for 1 file.  Also 'di-ruby-lvm' appears unused.
