### PR TITLE
added chef-manage addon

### DIFF
--- a/chef_backup.gemspec
+++ b/chef_backup.gemspec
@@ -28,4 +28,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'pry-rescue'
   spec.add_development_dependency 'rubocop', '~> 0.37.2'
   spec.add_development_dependency 'simplecov'
+  spec.add_development_dependency 'listen', '~> 3.0.0'
 end

--- a/lib/chef_backup/helpers.rb
+++ b/lib/chef_backup/helpers.rb
@@ -10,6 +10,10 @@ module Helpers
   # rubocop:enable IndentationWidth
 
   SERVER_ADD_ONS = {
+    'chef-manage' => {
+      'config_file' => '/etc/chef-manage/manage.rb',
+      'ctl_command' => 'chef-manage-ctl'
+    },
     'opscode-manage' => {
       'config_file' => '/etc/opscode-manage/manage.rb',
       'ctl_command' => 'opscode-manage-ctl'

--- a/lib/chef_backup/helpers.rb
+++ b/lib/chef_backup/helpers.rb
@@ -11,7 +11,7 @@ module Helpers
 
   SERVER_ADD_ONS = {
     'chef-manage' => {
-      'config_file' => '/etc/chef-manage/manage.rb',
+      'config_file' => '/var/opt/chef-manage/etc/settings.yml',
       'ctl_command' => 'chef-manage-ctl'
     },
     'opscode-manage' => {


### PR DESCRIPTION
It looks like there was an omission of `chef-manage` after opscode-manage was renamed chef-manage.  This PR adds the `chef-manage` addon and therefore allows `chef-server-ctl restore ..` command to run `chef-manage-ctl reconfigure` and `chef-manage-ctl restart` at the end of a restore.  Without restarting chef-manage-ctl, users are not able to log in via the manage ui following a restore operation; they get this error because the manage services have not yet picked up the new pivotal key:

```
2016-08-26T21:12:03Z erchef@127.0.0.1 method=POST; path=/authenticate_user; status=401; req_id=g3IAA2QAEGVyY2hlZkAxMjcuMC4wLjECAAAjOwAAAAAAAAAA; msg=bad_sig; couchdb_groups=false; couchdb_organizations=false; couchdb_containers=false; couchdb_acls=false; 503_mode=false; couchdb_associations=false; couchdb_association_requests=false; req_time=13; rdbms_time=8; rdbms_count=1; user=pivotal; req_api_version=0;
```
