### PR TITLE
Capture versions of addons.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -22,4 +22,5 @@ AllCops:
     - 'lib/chef_backup/mash.rb'
     - 'spec/unit/mash_spec.rb'
     - 'spec/unit/deep_merge_spec.rb'
+    - 'vendor/**/*'
     - 'Guardfile'

--- a/lib/chef_backup/data_map.rb
+++ b/lib/chef_backup/data_map.rb
@@ -11,11 +11,12 @@ module ChefBackup
       attr_writer :data_map
     end
 
-    attr_accessor :strategy, :backup_time, :topology, :configs, :services, :ha
+    attr_accessor :strategy, :backup_time, :topology, :configs, :services, :ha, :versions
 
     def initialize
       @services = {}
       @configs = {}
+      @versions = {}
       @ha = {}
       yield self if block_given?
 
@@ -31,7 +32,11 @@ module ChefBackup
 
     def add_config(config, path)
       @configs[config] ||= {}
-      @configs[config]['data_dir'] = path
+      @configs[config]['config'] = path
+    end
+
+    def add_version(project_name, data)
+      @versions[project_name] = data
     end
 
     def add_ha_info(k, v)
@@ -45,7 +50,8 @@ module ChefBackup
         'topology' => topology,
         'ha' => ha,
         'services' => services,
-        'configs' => configs
+        'configs' => configs,
+        'versions' => versions
       }
     end
   end

--- a/lib/chef_backup/helpers.rb
+++ b/lib/chef_backup/helpers.rb
@@ -4,6 +4,7 @@ require 'mixlib/shellout'
 require 'chef_backup/config'
 require 'chef_backup/logger'
 
+# rubocop:disable ModuleLength
 # rubocop:disable IndentationWidth
 module ChefBackup
 # Common helper methods that are usefull in many classes

--- a/lib/chef_backup/helpers.rb
+++ b/lib/chef_backup/helpers.rb
@@ -202,12 +202,9 @@ module Helpers
 
   def enabled_addons
     SERVER_ADD_ONS.select do |name, config|
-      begin
-        File.directory?(addon_install_dir(name)) &&
-          File.directory?(File.dirname(config['config_file']))
-      rescue
-        false
-      end
+      !config['config_file'].nil? &&
+        File.directory?(File.dirname(config['config_file'])) &&
+        File.directory?(addon_install_dir(name))
     end
   end
 

--- a/lib/chef_backup/helpers.rb
+++ b/lib/chef_backup/helpers.rb
@@ -1,4 +1,5 @@
 require 'fileutils'
+require 'json'
 require 'mixlib/shellout'
 require 'chef_backup/config'
 require 'chef_backup/logger'
@@ -27,7 +28,7 @@ module Helpers
       'ctl_command' => 'opscode-analytics-ctl'
     },
     'chef-ha' => {
-      'config_file' => 'etc/opscode/chef-server.rb'
+      'config_file' => '/etc/opscode/chef-server.rb'
     },
     'chef-sync' => {
       'config_file' => '/etc/chef-sync/chef-sync.rb',
@@ -116,6 +117,11 @@ module Helpers
     "/opt/#{project_name}"
   end
 
+  def addon_install_dir(name)
+    # can use extra field in SERVER_ADD_ONS to extend if someone isn't following this pattern.
+    "/opt/#{name}"
+  end
+
   def base_config_dir
     "/etc/#{project_name}"
   end
@@ -194,9 +200,10 @@ module Helpers
   end
 
   def enabled_addons
-    SERVER_ADD_ONS.select do |_name, config|
+    SERVER_ADD_ONS.select do |name, config|
       begin
-        File.directory?(File.dirname(config['config_file']))
+        File.directory?(addon_install_dir(name)) &&
+          File.directory?(File.dirname(config['config_file']))
       rescue
         false
       end
@@ -257,6 +264,20 @@ module Helpers
     FileUtils.rm_r(tmp_dir)
   rescue Errno::ENOENT
     true
+  end
+
+  def version_from_manifest_file(file)
+    return :no_version if file.nil?
+
+    path = File.expand_path(file)
+    if File.exist?(path)
+      config = JSON.parse(File.read(path))
+      { 'version' => config['build_version'],
+        'revision' => config['build_git_revision'],
+        'path' => path }
+    else
+      :no_version
+    end
   end
 
   private

--- a/lib/chef_backup/strategy/backup/tar.rb
+++ b/lib/chef_backup/strategy/backup/tar.rb
@@ -85,6 +85,12 @@ class TarBackup
       data_map.add_config(config, "/etc/#{config}")
     end
 
+    project_names.each do |project|
+      dir = addon_install_dir(project)
+      path = File.join(dir ,"/version-manifest.json")
+      data_map.add_version(project, version_from_manifest_file(path) )
+    end
+
     # Don't forget the upgrades!
     if service_config.key?('upgrades')
       data_map.add_service('upgrades', service_config['upgrades']['dir'])
@@ -127,6 +133,10 @@ class TarBackup
 
   def config_directories
     [project_name] + enabled_addons.keys
+  end
+
+  def project_names
+    ([project_name] + enabled_addons.keys).uniq
   end
 
   # The data_map is a working record of all of the data that is backed up.

--- a/lib/chef_backup/strategy/backup/tar.rb
+++ b/lib/chef_backup/strategy/backup/tar.rb
@@ -85,17 +85,24 @@ class TarBackup
       data_map.add_config(config, "/etc/#{config}")
     end
 
-    project_names.each do |project|
-      dir = addon_install_dir(project)
-      path = File.join(dir ,"/version-manifest.json")
-      data_map.add_version(project, version_from_manifest_file(path) )
-    end
+    populate_versions
 
     # Don't forget the upgrades!
     if service_config.key?('upgrades')
       data_map.add_service('upgrades', service_config['upgrades']['dir'])
     end
 
+    add_ha_services
+  end
+
+  def populate_versions
+    project_names.each do |project|
+      path = File.join(addon_install_dir(project), '/version-manifest.json')
+      data_map.add_version(project, version_from_manifest_file(path))
+    end
+  end
+
+  def add_ha_services
     if ha? && !config_only?
       data_map.add_service('keepalived', service_config['keepalived']['dir'])
       data_map.add_ha_info('provider', service_config['ha']['provider'])

--- a/lib/chef_backup/strategy/restore/tar.rb
+++ b/lib/chef_backup/strategy/restore/tar.rb
@@ -114,7 +114,7 @@ class TarRestore
   end
 
   def check_manifest_version
-    if !manifest['versions']
+    unless manifest['versions']
       log 'no version information in manifest'
       return true
     end
@@ -124,11 +124,10 @@ class TarRestore
 
       if installed == :no_version
         log "Warning: #{name} @ #{data['version']} not installed"
-      else
-        if (installed['version'] != data['version'])
-          log "package #{name} #{installed['version']} installed, but backup was from #{data['version']}. Please install correct version, restore, then upgrade."
-          return false
-        end
+      elsif installed['version'] != data['version']
+        log "package #{name} #{installed['version']} installed, but backup was"\
+            " from #{data['version']}. Please install correct version, restore, then upgrade."
+        return false
       end
     end
     true
@@ -186,6 +185,6 @@ class TarRestore
   def update_config
     ChefBackup::Config.config = deep_merge(config.dup, running_config)
   end
-  end # Tar
+end # Tar
 end # Strategy
 end # ChefBackup

--- a/spec/fixtures/manifest-stub.json
+++ b/spec/fixtures/manifest-stub.json
@@ -1,0 +1,6 @@
+{
+  "manifest_format": 2,
+  "build_version": "100.50.0",
+  "build_git_revision": "18af6b292bd4422d514ac83af6ad2b760662c21a",
+  "license": "Chef MLSA"
+}

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -34,6 +34,38 @@ def clear_config
   ChefBackup::Config.config = {}
 end
 
+def data_map_data
+  {
+    services: {
+      'postgresql' => {
+        'data_dir' => '/var/opt/opscode/postgresql_9.2/data'
+      },
+      'couchdb' => {
+        'data_dir' => '/var/opt/opscode/couchdb/data'
+      },
+      'rabbitmq' => {
+        'data_dir' => '/var/opt/opscode/rabbitdb/data'
+      }
+    },
+    configs: {
+      'opscode' => {
+        'data_dir' => '/etc/opscode'
+      },
+      'opscode-manage' => {
+        'data_dir' => '/etc/opscode-manage'
+      }
+    },
+    versions: {
+      'opscode' => { 'version' => '12.9.1',
+                     'revision' => 'aa7b99ac81ff4c018a0081e9a273b87b15342f12',
+                     'path' => '/opt/opscode/version-manifest.json' },
+      'opscode-manage' => { 'version' => '1.2.3',
+                            'revision' => 'deadbeef',
+                            'path' => '/opt/opscode-manage/version-manifest.json' }
+    }
+  }
+end
+
 def set_common_variables
   let(:backup_tarball) { '/tmp/chef-backup-2014-12-10-20-31-40.tgz' }
   let(:backup_time) { '2014-08-21T23:10:57-07:00' }
@@ -47,32 +79,7 @@ def set_common_variables
   end
   let(:enabled_services) { all_services }
   let(:data_map) do
-    double(
-      'DataMap',
-      services: {
-        'postgresql' => {
-          'data_dir' => '/var/opt/opscode/postgresql_9.2/data'
-        },
-        'couchdb' => {
-          'data_dir' => '/var/opt/opscode/couchdb/data'
-        },
-        'rabbitmq' => {
-          'data_dir' => '/var/opt/opscode/rabbitdb/data'
-        }
-      },
-      configs: {
-        'opscode' => {
-          'data_dir' => '/etc/opscode'
-        },
-        'opscode-manage' => {
-          'data_dir' => '/etc/opscode-manage'
-        }
-      },
-      versions: {
-        'opscode' => {'version'=>"12.9.1", 'revision'=>"aa7b99ac81ff4c018a0081e9a273b87b15342f12", 'path'=>"/opt/opscode/version-manifest.json"},
-        'opscode-manage' => {'version'=>"1.2.3", 'revision'=>"deadbeef", 'path'=>"/opt/opscode-manage/version-manifest.json"}
-      }
-    )
+    double('DataMap', data_map_data)
   end
 end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -67,6 +67,10 @@ def set_common_variables
         'opscode-manage' => {
           'data_dir' => '/etc/opscode-manage'
         }
+      },
+      versions: {
+        'opscode' => {'version'=>"12.9.1", 'revision'=>"aa7b99ac81ff4c018a0081e9a273b87b15342f12", 'path'=>"/opt/opscode/version-manifest.json"},
+        'opscode-manage' => {'version'=>"1.2.3", 'revision'=>"deadbeef", 'path'=>"/opt/opscode-manage/version-manifest.json"}
       }
     )
   end

--- a/spec/unit/data_map_spec.rb
+++ b/spec/unit/data_map_spec.rb
@@ -31,7 +31,7 @@ describe ChefBackup::DataMap do
   end
 
   describe '.add_version' do
-     subject { described_class.new }
+    subject { described_class.new }
 
     it 'adds a version' do
       subject.add_version('opscode-manage', :no_version)
@@ -39,7 +39,6 @@ describe ChefBackup::DataMap do
       expect(subject.versions['opscode-manage']).to eq(:no_version)
     end
   end
-
 
   describe '.manifest' do
     subject do

--- a/spec/unit/data_map_spec.rb
+++ b/spec/unit/data_map_spec.rb
@@ -25,10 +25,21 @@ describe ChefBackup::DataMap do
     it 'adds a config' do
       subject.add_config('opscode-manage', '/opscode-manage/path')
       expect(subject.configs.keys.count).to eq(1)
-      expect(subject.configs['opscode-manage']['data_dir'])
+      expect(subject.configs['opscode-manage']['config'])
         .to eq('/opscode-manage/path')
     end
   end
+
+  describe '.add_version' do
+     subject { described_class.new }
+
+    it 'adds a version' do
+      subject.add_version('opscode-manage', :no_version)
+      expect(subject.versions.keys.count).to eq(1)
+      expect(subject.versions['opscode-manage']).to eq(:no_version)
+    end
+  end
+
 
   describe '.manifest' do
     subject do

--- a/spec/unit/helpers_spec.rb
+++ b/spec/unit/helpers_spec.rb
@@ -87,23 +87,21 @@ describe ChefBackup::Helpers do
   end
 
   describe '.version_from_manifest_file' do
-    before do
-      @filepath = File.expand_path('../../fixtures/manifest-stub.json', __FILE__)
+    let(:filepath) do
+      filepath = File.expand_path('../../fixtures/manifest-stub.json', __FILE__)
+      filepath
     end
-
     it 'can read data out of a manifest' do
-      expect(subject.version_from_manifest_file(@filepath)).
-        to eq( 'version' => "1.4.0",  'revision' => "18af6b292bd4422d514ac83af6ad2b760662c21a",
-               'path' => "/home/vagrant/chef-server/omnibus/pkg/chef_backup/spec/fixtures/manifest-stub.json")
+      expect(subject.version_from_manifest_file(filepath))
+        .to eq('version' => '100.50.0',
+               'revision' => '18af6b292bd4422d514ac83af6ad2b760662c21a',
+               'path' => filepath)
     end
     it 'returns :no_version when missing one' do
-      expect(subject.version_from_manifest_file("/nonesuchfile")).
-        to eq( :no_version )
+      expect(subject.version_from_manifest_file('/nonesuchfile')).to eq(:no_version)
     end
     it 'returns :no_version when given nil' do
-      expect(subject.version_from_manifest_file(nil)).
-        to eq( :no_version )
+      expect(subject.version_from_manifest_file(nil)).to eq(:no_version)
     end
-
   end
 end

--- a/spec/unit/helpers_spec.rb
+++ b/spec/unit/helpers_spec.rb
@@ -85,4 +85,25 @@ describe ChefBackup::Helpers do
       subject.cleanup
     end
   end
+
+  describe '.version_from_manifest_file' do
+    before do
+      @filepath = File.expand_path('../../fixtures/manifest-stub.json', __FILE__)
+    end
+
+    it 'can read data out of a manifest' do
+      expect(subject.version_from_manifest_file(@filepath)).
+        to eq( 'version' => "1.4.0",  'revision' => "18af6b292bd4422d514ac83af6ad2b760662c21a",
+               'path' => "/home/vagrant/chef-server/omnibus/pkg/chef_backup/spec/fixtures/manifest-stub.json")
+    end
+    it 'returns :no_version when missing one' do
+      expect(subject.version_from_manifest_file("/nonesuchfile")).
+        to eq( :no_version )
+    end
+    it 'returns :no_version when given nil' do
+      expect(subject.version_from_manifest_file(nil)).
+        to eq( :no_version )
+    end
+
+  end
 end

--- a/spec/unit/strategy/backup/tar_spec.rb
+++ b/spec/unit/strategy/backup/tar_spec.rb
@@ -226,7 +226,9 @@ describe ChefBackup::Strategy::TarBackup do
     let(:configs) { %w(opscode opscode-manage opscode-analytics) }
     let(:versions) do
       {
-        'opscode' => {'version'=>"12.9.1", 'revision'=>"aa7b99ac81ff4c018a0081e9a273b87b15342f12", 'path'=>"/opt/opscode/version-manifest.json"},
+        'opscode' => { 'version' => '12.9.1',
+                       'revision' => 'aa7b99ac81ff4c018a0081e9a273b87b15342f12',
+                       'path' => '/opt/opscode/version-manifest.json' },
         'opscode-manage' => :no_version,
         'opscode-analytics' => :no_version
       }
@@ -292,25 +294,22 @@ describe ChefBackup::Strategy::TarBackup do
         private_chef('role' => 'standalone', 'backup' => { 'config_only' => true })
         data_mock = double('DataMap')
         allow(subject).to receive(:data_map).and_return(data_mock)
-        allow_any_instance_of(ChefBackup::Helpers).to receive(:version_from_manifest_file)
-                                                       .and_return(:version_stub)
-        allow(subject).to receive(:enabled_addons)
-                           .and_return( { 'opscode' => nil,
-                                          'opscode-manage' => nil,
-                                          'opscode-analytics' => nil})
+        allow_any_instance_of(ChefBackup::Helpers)
+          .to receive(:version_from_manifest_file).and_return(:version_stub)
+        allow(subject).to receive(:enabled_addons).and_return('opscode' => nil,
+                                                              'opscode-manage' => nil,
+                                                              'opscode-analytics' => nil)
       end
 
       it 'populates the data map with config and upgrade directories only' do
         configs.each do |config|
           expect(subject.data_map)
-            .to receive(:add_config)
-                 .with(config, "/etc/#{config}")
+            .to receive(:add_config).with(config, "/etc/#{config}")
         end
 
         versions.keys.each do |version|
           expect(subject.data_map)
-            .to receive(:add_version)
-                 .with(version, :version_stub)
+            .to receive(:add_version).with(version, :version_stub)
         end
 
         expect(subject.data_map)

--- a/spec/unit/strategy/backup/tar_spec.rb
+++ b/spec/unit/strategy/backup/tar_spec.rb
@@ -224,6 +224,13 @@ describe ChefBackup::Strategy::TarBackup do
   describe '.populate_data_map' do
     let(:services) { %w(opscode-solr4 bookshelf rabbitmq) }
     let(:configs) { %w(opscode opscode-manage opscode-analytics) }
+    let(:versions) do
+      {
+        'opscode' => {'version'=>"12.9.1", 'revision'=>"aa7b99ac81ff4c018a0081e9a273b87b15342f12", 'path'=>"/opt/opscode/version-manifest.json"},
+        'opscode-manage' => :no_version,
+        'opscode-analytics' => :no_version
+      }
+    end
     let(:config) do
       { 'bookshelf' => { 'data_dir' => '/bookshelf/data' },
         'opscode-solr4' => { 'data_dir' => '/solr4/data' },
@@ -235,7 +242,7 @@ describe ChefBackup::Strategy::TarBackup do
       allow(subject).to receive(:data_map).and_return(data_map)
       allow(subject).to receive(:stateful_services).and_return(services)
       allow(subject).to receive(:config_directories).and_return(configs)
-      %w(add_service add_config add_ha_info).each do |method|
+      %w(add_service add_config add_ha_info add_version).each do |method|
         allow(data_map).to receive(method.to_sym).and_return(true)
       end
     end
@@ -285,13 +292,25 @@ describe ChefBackup::Strategy::TarBackup do
         private_chef('role' => 'standalone', 'backup' => { 'config_only' => true })
         data_mock = double('DataMap')
         allow(subject).to receive(:data_map).and_return(data_mock)
+        allow_any_instance_of(ChefBackup::Helpers).to receive(:version_from_manifest_file)
+                                                       .and_return(:version_stub)
+        allow(subject).to receive(:enabled_addons)
+                           .and_return( { 'opscode' => nil,
+                                          'opscode-manage' => nil,
+                                          'opscode-analytics' => nil})
       end
 
       it 'populates the data map with config and upgrade directories only' do
         configs.each do |config|
           expect(subject.data_map)
             .to receive(:add_config)
-            .with(config, "/etc/#{config}")
+                 .with(config, "/etc/#{config}")
+        end
+
+        versions.keys.each do |version|
+          expect(subject.data_map)
+            .to receive(:add_version)
+                 .with(version, :version_stub)
         end
 
         expect(subject.data_map)

--- a/spec/unit/strategy/restore/tar_spec.rb
+++ b/spec/unit/strategy/restore/tar_spec.rb
@@ -23,6 +23,13 @@ describe ChefBackup::Strategy::TarRestore do
         'opscode-manage' => { 'data_dir' => '/etc/opscode-manage' },
         'opscode-reporting' => { 'data_dir' => '/etc/opscode-reporting' },
         'opscode-analytics' => { 'data_dir' => '/etc/opscode-analytics' }
+      },
+      'versions' => {
+        'opscode' => { 'version' => '1.2.3', 'revision' => 'deadbeef11', 'path' => '/opt/opscode/version_manifest.json' },
+        'opscode-manage' => { 'version' => '4.5.6', 'revision' => 'deadbeef12', 'path' => '/opt/opscode-manage/version_manifest.json' },
+        'opscode-reporting' => { 'version' => '7.8.9', 'revision' => 'deadbeef13', 'path' => '/opt/opscode-reporting/version_manifest.json' },
+        'opscode-analytics' => { 'version' => '10.11.12', 'revision'  => 'abcdef1234', 'path' => '/opt/opscode-analytics/version_manifest.json' }
+
       }
     }
   end
@@ -190,6 +197,59 @@ describe ChefBackup::Strategy::TarRestore do
       end
     end
   end
+
+  describe '.check_manifest_version' do
+    let(:manifest_messages) do
+      manifest['versions'].values.inject({}) do |a, v|
+        a[v['path']] = v
+        a
+      end
+    end
+
+    before do
+      allow(subject).to receive(:manifest).and_return(manifest)
+    end
+
+    it 'succeeds if installed software is same version' do
+      manifest['versions'].values.each do |v|
+        allow_any_instance_of(ChefBackup::Helpers).to receive(:version_from_manifest_file).
+                                       with(v['path']).and_return(v)
+      end
+      expect(subject.check_manifest_version).to be true
+    end
+    it 'fails if installed software is different version' do
+      manifest['versions'].values.each do |v|
+        vmod = v.clone
+        vmod['version'] = '0.0.0'
+        allow_any_instance_of(ChefBackup::Helpers).to receive(:version_from_manifest_file).
+                                       with(v['path']).and_return(vmod)
+      end
+
+      expect(subject.check_manifest_version).to be false
+    end
+    it 'warns if installed software is missing' do
+      messages = Marshal.load(Marshal.dump(manifest_messages))
+      messages["/opt/opscode-manage/version_manifest.json"] = :no_version
+
+      allow_any_instance_of(ChefBackup::Helpers).to receive(:version_from_manifest_file) do |p|
+        messages[p]
+      end
+
+      expect(subject.check_manifest_version).to be true
+    end
+    it 'it warns if missing' do
+      mod_manifest = Marshal.load(Marshal.dump(manifest))
+      mod_manifest['versions'].delete('opscode-reporting')
+      allow(subject).to receive(:manifest).and_return(mod_manifest)
+
+      manifest['versions'].values.each do |v|
+        allow_any_instance_of(ChefBackup::Helpers).to receive(:version_from_manifest_file).
+                                       with(v['path']).and_return(:no_version)
+      end
+      expect(subject.check_manifest_version).to be true
+    end
+  end
+
 
   describe '.import_db' do
     let(:pg_options) { ["PGOPTIONS=#{ChefBackup::Helpers::DEFAULT_PG_OPTIONS}"] }

--- a/spec/unit/strategy/restore/tar_spec.rb
+++ b/spec/unit/strategy/restore/tar_spec.rb
@@ -25,10 +25,14 @@ describe ChefBackup::Strategy::TarRestore do
         'opscode-analytics' => { 'data_dir' => '/etc/opscode-analytics' }
       },
       'versions' => {
-        'opscode' => { 'version' => '1.2.3', 'revision' => 'deadbeef11', 'path' => '/opt/opscode/version_manifest.json' },
-        'opscode-manage' => { 'version' => '4.5.6', 'revision' => 'deadbeef12', 'path' => '/opt/opscode-manage/version_manifest.json' },
-        'opscode-reporting' => { 'version' => '7.8.9', 'revision' => 'deadbeef13', 'path' => '/opt/opscode-reporting/version_manifest.json' },
-        'opscode-analytics' => { 'version' => '10.11.12', 'revision'  => 'abcdef1234', 'path' => '/opt/opscode-analytics/version_manifest.json' }
+        'opscode' => { 'version' => '1.2.3', 'revision' => 'deadbeef11',
+                       'path' => '/opt/opscode/version_manifest.json' },
+        'opscode-manage' => { 'version' => '4.5.6', 'revision' => 'deadbeef12',
+                              'path' => '/opt/opscode-manage/version_manifest.json' },
+        'opscode-reporting' => { 'version' => '7.8.9', 'revision' => 'deadbeef13',
+                                 'path' => '/opt/opscode-reporting/version_manifest.json' },
+        'opscode-analytics' => { 'version' => '10.11.12', 'revision' => 'abcdef1234',
+                                 'path' => '/opt/opscode-analytics/version_manifest.json' }
 
       }
     }
@@ -200,9 +204,8 @@ describe ChefBackup::Strategy::TarRestore do
 
   describe '.check_manifest_version' do
     let(:manifest_messages) do
-      manifest['versions'].values.inject({}) do |a, v|
+      manifest['versions'].values.each_with_object({}) do |v, a|
         a[v['path']] = v
-        a
       end
     end
 
@@ -212,8 +215,8 @@ describe ChefBackup::Strategy::TarRestore do
 
     it 'succeeds if installed software is same version' do
       manifest['versions'].values.each do |v|
-        allow_any_instance_of(ChefBackup::Helpers).to receive(:version_from_manifest_file).
-                                       with(v['path']).and_return(v)
+        allow_any_instance_of(ChefBackup::Helpers)
+          .to receive(:version_from_manifest_file).with(v['path']).and_return(v)
       end
       expect(subject.check_manifest_version).to be true
     end
@@ -221,15 +224,15 @@ describe ChefBackup::Strategy::TarRestore do
       manifest['versions'].values.each do |v|
         vmod = v.clone
         vmod['version'] = '0.0.0'
-        allow_any_instance_of(ChefBackup::Helpers).to receive(:version_from_manifest_file).
-                                       with(v['path']).and_return(vmod)
+        allow_any_instance_of(ChefBackup::Helpers)
+          .to receive(:version_from_manifest_file).with(v['path']).and_return(vmod)
       end
 
       expect(subject.check_manifest_version).to be false
     end
     it 'warns if installed software is missing' do
       messages = Marshal.load(Marshal.dump(manifest_messages))
-      messages["/opt/opscode-manage/version_manifest.json"] = :no_version
+      messages['/opt/opscode-manage/version_manifest.json'] = :no_version
 
       allow_any_instance_of(ChefBackup::Helpers).to receive(:version_from_manifest_file) do |p|
         messages[p]
@@ -243,13 +246,12 @@ describe ChefBackup::Strategy::TarRestore do
       allow(subject).to receive(:manifest).and_return(mod_manifest)
 
       manifest['versions'].values.each do |v|
-        allow_any_instance_of(ChefBackup::Helpers).to receive(:version_from_manifest_file).
-                                       with(v['path']).and_return(:no_version)
+        allow_any_instance_of(ChefBackup::Helpers)
+          .to receive(:version_from_manifest_file).with(v['path']).and_return(:no_version)
       end
       expect(subject.check_manifest_version).to be true
     end
   end
-
 
   describe '.import_db' do
     let(:pg_options) { ["PGOPTIONS=#{ChefBackup::Helpers::DEFAULT_PG_OPTIONS}"] }


### PR DESCRIPTION
Use version-manifest.json as source of truth to
1) determine if addons are installed
2) capture version of software from backup
3) block restore when version numbers don't match.

Signed-off-by: Mark Anderson mark@chef.io
