### PR TITLE
Fix Backups

### DIFF
--- a/chef_backup.gemspec
+++ b/chef_backup.gemspec
@@ -22,7 +22,8 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'highline'
 
   spec.add_development_dependency 'bundler', '~> 1.6'
-  spec.add_development_dependency 'rake'
+  spec.add_development_dependency 'rainbow', '< 2.2.0'
+  spec.add_development_dependency 'rake', '< 11.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'guard-rspec'
   spec.add_development_dependency 'pry-rescue'

--- a/lib/chef_backup/data_map.rb
+++ b/lib/chef_backup/data_map.rb
@@ -32,7 +32,7 @@ module ChefBackup
 
     def add_config(config, path)
       @configs[config] ||= {}
-      @configs[config]['config'] = path
+      @configs[config]['data_dir'] = path
     end
 
     def add_version(project_name, data)

--- a/spec/unit/data_map_spec.rb
+++ b/spec/unit/data_map_spec.rb
@@ -25,7 +25,7 @@ describe ChefBackup::DataMap do
     it 'adds a config' do
       subject.add_config('opscode-manage', '/opscode-manage/path')
       expect(subject.configs.keys.count).to eq(1)
-      expect(subject.configs['opscode-manage']['config'])
+      expect(subject.configs['opscode-manage']['data_dir'])
         .to eq('/opscode-manage/path')
     end
   end


### PR DESCRIPTION
The `DataMap` classes `addconfig` method was putting the config directory under a `config` key, rather than `data_dir` key which is referenced by the restore process.

https://github.com/chef/chef_backup/blob/master/lib/chef_backup/data_map.rb#L35

Attempt to address #26 and https://github.com/chef/chef-server/issues/1020

As you can see in the manifest below, the `services` have a `data_dir` defined, but `configs` does not.

```json
{
  "strategy": "tar",
  "backup_time": "2016-12-08-06-34-27",
  "topology": "standalone",
  "ha": {
  },
  "services": {
    "rabbitmq": {
      "data_dir": "/var/opt/opscode/rabbitmq/db"
    },
    "opscode-solr4": {
      "data_dir": "/var/opt/opscode/opscode-solr4/data"
    },
    "redis_lb": {
      "data_dir": "/var/opt/opscode/redis_lb/data"
    },
    "postgresql": {
      "data_dir": "/var/opt/opscode/postgresql/9.2/data",
      "pg_dump_success": true,
      "username": "opscode-pgsql"
    },
    "bookshelf": {
      "data_dir": "/var/opt/opscode/bookshelf/data"
    },
    "upgrades": {
      "data_dir": "/var/opt/opscode/upgrades"
    }
  },
  "configs": {
    "opscode": {
      "config": "/etc/opscode"
    }
  },
  "versions": {
    "opscode": {
      "version": "12.11.0",
      "revision": "5c836a047ed5e5124b52bb946abc18c71c297024",
      "path": "/opt/opscode/version-manifest.json"
    }
  }
}
```