### PR TITLE
Replace highline with pastel and tty-prompt

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -1,16 +1,6 @@
 ---
 
 steps:
-- label: run-specs-ruby-2.5
-  command:
-    - bundle config set --local without docs development
-    - bundle install --jobs=7 --retry=3
-    - bundle exec rake
-  expeditor:
-    executor:
-      docker:
-        image: ruby:2.5-stretch
-
 - label: run-specs-ruby-2.6
   command:
     - bundle config set --local without docs development
@@ -19,4 +9,14 @@ steps:
   expeditor:
     executor:
       docker:
-        image: ruby:2.6-stretch
+        image: rubydistros/ubuntu-18.04:2.6
+
+- label: run-specs-ruby-3.0
+  command:
+    - bundle config set --local without docs development
+    - bundle install --jobs=7 --retry=3
+    - bundle exec rake
+  expeditor:
+    executor:
+      docker:
+        image: rubydistros/ubuntu-18.04:3.0

--- a/Rakefile
+++ b/Rakefile
@@ -33,7 +33,7 @@ task :console do
   require "pry"
   require "chef_backup"
   require "json"
-  f = File.expand_path("../spec/fixtures/chef-server-running.json", __FILE__)
+  f = File.expand_path("spec/fixtures/chef-server-running.json", __dir__)
   running_config = JSON.parse(File.read(f))
   @runner = ChefBackup::Runner.new(
     running_config.merge("restore_param" => "/tmp/backup.tgz")

--- a/chef_backup.gemspec
+++ b/chef_backup.gemspec
@@ -18,5 +18,5 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "mixlib-shellout", ">= 2.0", "< 4.0"
-  spec.add_dependency "highline", "~> 1.6", ">= 1.6.9"
+  spec.add_dependency "pastel"
 end

--- a/chef_backup.gemspec
+++ b/chef_backup.gemspec
@@ -1,6 +1,4 @@
-# coding: utf-8
-
-lib = File.expand_path("../lib", __FILE__)
+lib = File.expand_path("lib", __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "chef_backup/version"
 

--- a/chef_backup.gemspec
+++ b/chef_backup.gemspec
@@ -19,4 +19,5 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "mixlib-shellout", ">= 2.0", "< 4.0"
   spec.add_dependency "pastel"
+  spec.add_dependency "tty-prompt", "~> 0.21"
 end

--- a/lib/chef_backup/config.rb
+++ b/lib/chef_backup/config.rb
@@ -1,6 +1,6 @@
-require "fileutils"
-require "json"
-require "forwardable"
+require "fileutils" unless defined?(FileUtils)
+require "json" unless defined?(JSON)
+require "forwardable" unless defined?(Forwardable)
 
 module ChefBackup
   # ChefBackup Global Config

--- a/lib/chef_backup/data_map.rb
+++ b/lib/chef_backup/data_map.rb
@@ -1,4 +1,4 @@
-require "time"
+require "time" unless defined?(Time.zone_offset)
 
 module ChefBackup
   # DataMap class to store data about the data we're backing up

--- a/lib/chef_backup/logger.rb
+++ b/lib/chef_backup/logger.rb
@@ -1,5 +1,3 @@
-require "highline"
-
 module ChefBackup
   # Basic Logging Class
   class Logger
@@ -16,17 +14,24 @@ module ChefBackup
 
     def initialize(logfile = nil)
       $stdout = logfile ? File.open(logfile, "ab") : $stdout
-      @highline = HighLine.new($stdin, $stdout)
+    end
+
+    # pastel.decorate is a lightweight replacement for highline.color
+    def pastel
+      @pastel ||= begin
+        require "pastel" unless defined?(Pastel)
+        Pastel.new
+      end
     end
 
     def log(msg, level = :info)
       case level
       when :warn
         msg = "WARNING: #{msg}"
-        $stdout.puts(color? ? @highline.color(msg, :yellow) : msg)
+        $stdout.puts(color? ? pastel.decorate(msg, :yellow) : msg)
       when :error
         msg = "ERROR: #{msg}"
-        $stdout.puts(color? ? @highline.color(msg, :red) : msg)
+        $stdout.puts(color? ? pastel.decorate(msg, :red) : msg)
       else
         $stdout.puts(msg)
       end

--- a/lib/chef_backup/runner.rb
+++ b/lib/chef_backup/runner.rb
@@ -1,5 +1,5 @@
-require "fileutils"
-require "pathname"
+require "fileutils" unless defined?(FileUtils)
+require "pathname" unless defined?(Pathname)
 
 module ChefBackup
   # ChefBackup::Runner class initializes the strategy and runs the action
@@ -60,16 +60,14 @@ module ChefBackup
     # @return [String] A path to backup tarball or EBS snapshot ID
     #
     def restore_strategy
-      @restore_strategy ||= begin
-        if tarball?
-          unpack_tarball
-          manifest["strategy"]
-        elsif ebs_snapshot?
-          "ebs"
-        else
-          raise InvalidStrategy, "#{restore_param} is not a valid backup"
-        end
-      end
+      @restore_strategy ||= if tarball?
+                              unpack_tarball
+                              manifest["strategy"]
+                            elsif ebs_snapshot?
+                              "ebs"
+                            else
+                              raise InvalidStrategy, "#{restore_param} is not a valid backup"
+                            end
     end
 
     #

--- a/lib/chef_backup/strategy/backup/tar.rb
+++ b/lib/chef_backup/strategy/backup/tar.rb
@@ -1,7 +1,6 @@
 require 'fileutils'
 require 'json'
 require 'time'
-require 'highline/import'
 
 # rubocop:disable IndentationWidth
 module ChefBackup
@@ -244,7 +243,8 @@ class TarBackup
     msg << 'continuing.  You can skip this message by passing a "--yes" '
     msg << 'argument. Do you wish to proceed? (y/N):'
 
-    exit(1) unless ask(msg) =~ /^y/i
+    require "tty-prompt" unless defined?(TTY::Prompt)
+    exit(1) unless TTY::Prompt.new(interrupt: :exit).ask(msg) =~ /^y/i
   end
 end
 end

--- a/lib/chef_backup/strategy/restore/tar.rb
+++ b/lib/chef_backup/strategy/restore/tar.rb
@@ -1,6 +1,6 @@
-require "fileutils"
-require "pathname"
-require "forwardable"
+require "fileutils" unless defined?(FileUtils)
+require "pathname" unless defined?(Pathname)
+require "forwardable" unless defined?(Forwardable)
 require "chef_backup/deep_merge"
 
 # rubocop:disable IndentationWidth

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -84,7 +84,7 @@ end
 
 def running_config
   @config ||= begin
-    f = File.expand_path("../fixtures/chef-server-running.json", __FILE__)
+    f = File.expand_path("fixtures/chef-server-running.json", __dir__)
     JSON.parse(File.read(f))
   end
   @config.dup

--- a/spec/unit/helpers_spec.rb
+++ b/spec/unit/helpers_spec.rb
@@ -88,7 +88,7 @@ describe ChefBackup::Helpers do
 
   describe ".version_from_manifest_file" do
     let(:filepath) do
-      filepath = File.expand_path("../../fixtures/manifest-stub.json", __FILE__)
+      filepath = File.expand_path("../fixtures/manifest-stub.json", __dir__)
       filepath
     end
     it "can read data out of a manifest" do


### PR DESCRIPTION
replaces highline.color with pastel.decorate and highline.ask with tty-prompt.ask

We had started removing the use of highline from chef/chef: https://github.com/chef/chef/issues/9359

I can't remember exactly right now why, but I think it was that highline had lots of different functionality in a single gem while the tty-* gems let us choose à la carte. Currently chef/chef is using highline 2.0.3, and we're pinned to < 2.0 with the pessimistic version constraint.  We should be able to just relax that constraint, but moving to the more lightweight options should be better overall, at least in the long run.

