### PR TITLE
Replace trademarks hardcodes with constants

### DIFF
--- a/chef_backup.gemspec
+++ b/chef_backup.gemspec
@@ -18,4 +18,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency "mixlib-shellout", ">= 2.0", "< 4.0"
   spec.add_dependency "pastel"
   spec.add_dependency "tty-prompt", "~> 0.21"
+  spec.add_dependency "chef-utils", ">= 16.5.54" # for ChefUtils::Dist constants
 end

--- a/lib/chef_backup/config.rb
+++ b/lib/chef_backup/config.rb
@@ -1,6 +1,7 @@
 require "fileutils" unless defined?(FileUtils)
 require "json" unless defined?(JSON)
 require "forwardable" unless defined?(Forwardable)
+require "chef-utils/dist" unless defined?(ChefUtils::Dist)
 
 module ChefBackup
   # ChefBackup Global Config
@@ -12,10 +13,10 @@ module ChefBackup
       "backup" => {
         "always_dump_db" => true,
         "strategy" => "none",
-        "export_dir" => "/var/opt/chef-backup",
-        "project_name" => "opscode",
-        "ctl-command" => "chef-server-ctl",
-        "running_filepath" => "/etc/opscode/chef-server-running.json",
+        "export_dir" => "/var/opt/#{ChefUtils::Dist::Infra::SHORT}-backup",
+        "project_name" => ChefUtils::Dist::Org::LEGACY_CONF_DIR,
+        "ctl-command" => ChefUtils::Dist::Server::SERVER_CTL,
+        "running_filepath" => "/etc/#{ChefUtils::Dist::Org::LEGACY_CONF_DIR}/#{ChefUtils::Dist::Server::SERVER}-running.json",
         "database_name" => "opscode_chef",
       },
     }.freeze

--- a/lib/chef_backup/helpers.rb
+++ b/lib/chef_backup/helpers.rb
@@ -3,6 +3,7 @@ require 'json'
 require 'mixlib/shellout'
 require 'chef_backup/config'
 require 'chef_backup/logger'
+require 'chef-utils/dist'
 
 # rubocop:disable ModuleLength
 # rubocop:disable IndentationWidth
@@ -29,7 +30,7 @@ module Helpers
       'ctl_command' => 'opscode-analytics-ctl'
     },
     'chef-ha' => {
-      'config_file' => '/etc/opscode/chef-server.rb'
+      'config_file' => "/etc/#{ChefUtils::Dist::Org::LEGACY_CONF_DIR}/#{ChefUtils::Dist::Server::SERVER}.rb"
     },
     'chef-sync' => {
       'config_file' => '/etc/chef-sync/chef-sync.rb',

--- a/lib/chef_backup/strategy/restore/tar.rb
+++ b/lib/chef_backup/strategy/restore/tar.rb
@@ -1,6 +1,7 @@
 require "fileutils" unless defined?(FileUtils)
 require "pathname" unless defined?(Pathname)
 require "forwardable" unless defined?(Forwardable)
+require "chef-utils/dist" unless defined?(ChefUtils::Dist)
 require "chef_backup/deep_merge"
 
 # rubocop:disable IndentationWidth
@@ -93,7 +94,7 @@ class TarRestore
   end
 
   def touch_sentinel
-    dir = "/var/opt/opscode"
+    dir = "/var/opt/#{ChefUtils::Dist::Org::LEGACY_CONF_DIR}"
     sentinel = File.join(dir, "bootstrapped")
     FileUtils.mkdir_p(dir) unless File.directory?(dir)
     File.open(sentinel, "w") { |file| file.write "bootstrapped!" }
@@ -135,11 +136,11 @@ class TarRestore
 
   def fix_ha_plugins
     log "Fixing HA plugins directory (https://github.com/chef/chef-server/issues/115)"
-    plugins_dir = "/var/opt/opscode/plugins"
+    plugins_dir = "/var/opt/#{ChefUtils::Dist::Org::LEGACY_CONF_DIR}/plugins"
     drbd_plugin = File.join(plugins_dir, "chef-ha-drbd.rb")
 
     FileUtils.mkdir_p(plugins_dir) unless Dir.exist?(plugins_dir)
-    FileUtils.ln_sf("/opt/opscode/chef-server-plugin.rb", drbd_plugin) unless
+    FileUtils.ln_sf("/opt/#{ChefUtils::Dist::Org::LEGACY_CONF_DIR}/chef-server-plugin.rb", drbd_plugin) unless
       File.exist?(drbd_plugin)
   end
 
@@ -158,8 +159,8 @@ class TarRestore
 
   def touch_drbd_ready
     log "Touching drbd_ready file"
-    FileUtils.touch("/var/opt/opscode/drbd/drbd_ready") unless
-      File.exist?("/var/opt/opscode/drbd/drbd_ready")
+    FileUtils.touch("/var/opt/#{ChefUtils::Dist::Org::LEGACY_CONF_DIR}/drbd/drbd_ready") unless
+      File.exist?("/var/opt/#{ChefUtils::Dist::Org::LEGACY_CONF_DIR}/drbd/drbd_ready")
   end
 
   def reconfigure_server


### PR DESCRIPTION
Replacing trademarks ("opscode", "chef", "chef-server") with ChefUtils::Dist constants. 

## Description

That change required to accomplish trademarks replacement in ChefServer (https://github.com/chef/chef-server/pull/3101/).

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

