### PR TITLE
CHEF-30482 - Replace CONTRIBUTING.md file with standard template for Inspec

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,1 +1,3 @@
-Please refer to https://github.com/chef/chef/blob/master/CONTRIBUTING.md
+# Contributing to a Progress Chef InSpec Project
+
+Thank you for your interest in contributing to this project! It is part of the larger Progress Chef InSpec project. Contribution guidelines can be found at [Contributing to Progress Chef InSpec](https://chef.github.io/chef-oss-practices/projects/inspec/contributing/).


### PR DESCRIPTION
This pull request replaces CONTRIBUTING.md file with the standard template for the Inspec project.  As part of the [repo standardization effort](https://github.com/chef-boneyard/oss-repo-standardization-2025) we are replacing all the different contributing guides with a standard template that links to a published version of the chef-oss-practices repo.
This PR is intended to be a mere mechanical change, not a change in policy. Watch chef/chef-oss-practices for changes in policy. 