### PR TITLE
CHEF-30484 Update and standardize copyright notices to Progress Software Corporation - copyright_update

### DIFF
--- a/COPYRIGHT.md
+++ b/COPYRIGHT.md
@@ -1,0 +1,1 @@
+Copyright (c) 2014-2022 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,3 @@
-Copyright 2014 Chef Software, Inc
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -19,3 +19,6 @@ chef-server-ctl restore some_backup.tgz
 3. Commit your changes (`git commit -am 'Add some feature'`)
 4. Push to the branch (`git push origin my-new-feature`)
 5. Create a new Pull Request
+
+# Copyright
+See [COPYRIGHT.md](./COPYRIGHT.md).

--- a/lib/chef_backup.rb
+++ b/lib/chef_backup.rb
@@ -1,4 +1,4 @@
-# Copyright:: Copyright (c) 2014 Chef, Inc.
+# Copyright (c) 2014-2022 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 #
 # All Rights Reserved
 

--- a/lib/chef_backup/deep_merge.rb
+++ b/lib/chef_backup/deep_merge.rb
@@ -1,7 +1,7 @@
 #
 # Author:: Adam Jacob (<adam@chef.io>)
 # Author:: Steve Midgley (http://www.misuse.org/science)
-# Copyright:: Copyright 2009-2016, Chef Software Inc.
+# Copyright:: Copyright (c) 2014-2022 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 # Copyright:: Copyright 2008-2016, Steve Midgley
 # License:: Apache License, Version 2.0
 #

--- a/lib/chef_backup/strategy.rb
+++ b/lib/chef_backup/strategy.rb
@@ -1,4 +1,4 @@
-# Copyright:: Copyright (c) 2014 Chef, Inc.
+# Copyright (c) 2014-2022 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 #
 # All Rights Reserved
 

--- a/spec/unit/mash_spec.rb
+++ b/spec/unit/mash_spec.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Matthew Kent (<mkent@magoazul.com>)
-# Copyright:: Copyright 2011-2016, Chef Software Inc.
+# Copyright:: Copyright (c) 2014-2022 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
This is an automated message using the copyright-automator tool.

This PR updates copyright notices from Chef Software and Opscode to Progress Software Corporation as part of the repository standardization effort.

## Automated Changes

- Updated Opscode, Chef, and Progress copyright notices to use Progress Software Corporation current language
- Applied year range: 2014-2022 reflecting our understanding of repo-specific activity
- Preserved original formatting and comment styles

## Manual Changes Required

⚠️ This PR requires manual intervention for the following files:

- `COPYRIGHT.md:1` - adjust-copyright-file
- `LICENSE:1` - Copyright in LICENSE file (move to COPYRIGHT)
- `README.md:1` - adjust-readme
- `lib/chef_backup.rb:1` - Unmatched copyright format (review needed)
- `lib/chef_backup/strategy.rb:1` - Unmatched copyright format (review needed)

Please review these locations and make appropriate manual edits.

## No Other Changes Intended

- No change to Author, Contributor, or Maintainer information
- No change to non-PSC copyright holders
